### PR TITLE
path{.go,._test.go}: catch staticcheck.conf lookups above @

### DIFF
--- a/path.go
+++ b/path.go
@@ -131,6 +131,16 @@ func parsePath(name string) (ret gmPath) {
 			ret.NotExist = true
 			return
 		}
+
+		// staticcheck walks the directory, looking for staticcheck.conf and
+		// does not stop at '@' - make sure we don't tell it that there is a
+		// foo/bar/staticcheck.conf directory that it will then attempt to parse
+		// as its config file.
+		// https://github.com/tailscale/gomodfs/issues/17
+		if base == "staticcheck.conf" {
+			ret.NotExist = true
+			return
+		}
 		return
 	}
 	escVer, path, _ := strings.Cut(verAndPath, "/")

--- a/path_test.go
+++ b/path_test.go
@@ -85,6 +85,26 @@ var pathTests = []struct {
 	{path: "foo/bar", want: gmPath{}},
 	{path: "foo/bar/baz", want: gmPath{}},
 	{path: "foo/bar/baz", want: gmPath{}},
+
+	// https://github.com/tailscale/gomodfs/issues/17
+	{path: "github.com/go4.org/staticcheck.conf", want: gmPath{NotExist: true}},
+	{path: "github.com/go4.org/mem/staticcheck.conf", want: gmPath{NotExist: true}},
+	{
+		path: "github.com/go4.org/mem@v2.17.2/staticcheck.conf",
+		want: gmPath{
+			ModVersion: store.ModuleVersion{Module: "github.com/go4.org/mem", Version: "v2.17.2"},
+			InZip:      true,
+			Path:       "staticcheck.conf",
+		},
+	},
+	{
+		path: "github.com/go4.org/mem@v2.17.2/foo/bar/staticcheck.conf",
+		want: gmPath{
+			ModVersion: store.ModuleVersion{Module: "github.com/go4.org/mem", Version: "v2.17.2"},
+			InZip:      true,
+			Path:       "foo/bar/staticcheck.conf",
+		},
+	},
 	{
 		path: "github.com/tailscale/web-client-prebuilt@v0.0.0-20250124233751-d4cd19a26976/build/", // with trailing slash
 		want: gmPath{


### PR DESCRIPTION
Special case lookups for path that end with `staticcheck.conf` - assume that this is staticcheck looking for its configfiles above `@` rather than a legitimate module path being built and return 'not exists' to avoid staticcheck failing when attempting to parse the returned as its configfile.

Updates #17