### PR TITLE
pacify cmd/go's "go mod download" with zero byte (empty) cache/download/*.zip files

### DIFF
--- a/gomodfs.go
+++ b/gomodfs.go
@@ -488,6 +488,7 @@ type pathHash [sha256.Size]byte
 var (
 	cdFileInfo    = mkWellKnownPathHash("info")
 	cdFileMod     = mkWellKnownPathHash("mod")
+	cdFileZip     = mkWellKnownPathHash("zip")
 	cdFileZiphash = mkWellKnownPathHash("ziphash")
 	pathHashTSGo  = mkWellKnownPathHash(wkTSGoExtracted)
 )

--- a/nfs.go
+++ b/nfs.go
@@ -232,6 +232,10 @@ func (b billyFS) Lstat(filename string) (os.FileInfo, error) {
 	ctx := context.TODO()
 
 	if ext := mp.CacheDownloadFileExt; ext != "" {
+		if ext == "zip" {
+			// The "zip" file is unused by cmd/go, so just return an empty file.
+			return regFileInfo{name: filepath.Base(filename), size: 0}, nil
+		}
 		v, err := b.fs.getMetaFileByExt(ctx, mp.ModVersion, ext)
 		if err != nil {
 			b.fs.logf("Failed to get %s file for %v: %v", ext, mp.ModVersion, err)
@@ -434,6 +438,8 @@ func (h *NFSHandler) fromHandle(handle handle) (ret handleTarget, err error) {
 		return mkTargetFromPath(cdPath(mv, "info")), nil
 	case cdFileMod:
 		return mkTargetFromPath(cdPath(mv, "mod")), nil
+	case cdFileZip:
+		return mkTargetFromPath(cdPath(mv, "zip")), nil
 	case cdFileZiphash:
 		return mkTargetFromPath(cdPath(mv, "ziphash")), nil
 	case pathHashTSGo:
@@ -677,6 +683,10 @@ func (n *NFSHandler) getFileContentsUncached(ctx context.Context, filename strin
 	}
 
 	if ext := mp.CacheDownloadFileExt; ext != "" {
+		if ext == "zip" {
+			// The "zip" file is unused by cmd/go, so just return an empty file.
+			return []byte{}, attr, nil
+		}
 		sp := n.fs.Stats.StartSpan("nfs.OpenFile-ext-" + ext)
 		v, err := n.fs.getMetaFileByExt(ctx, mp.ModVersion, ext)
 		sp.End(err)

--- a/path.go
+++ b/path.go
@@ -27,9 +27,11 @@ type gmPath struct {
 	// are just checking for, but don't exist in the gomodfs hierarchy.
 	NotExist bool
 
-	// CacheDownloadFileExt is one of "mod", "ziphash", "info"
+	// CacheDownloadFileExt is one of "mod", "ziphash", "info", or "zip".
 	// if the path is for "cache/download/<module>/@v/<version>.<CacheDownloadFileExt>".
 	// If non-empty, then ModVersion is also populated.
+	// The file contents for the "zip" file are unused by cmd/go, so gomodfs
+	// just pretends it exists and returns an empty file.
 	CacheDownloadFileExt string
 
 	// InZip, if true, means that the path is within the contents of a zip
@@ -108,7 +110,7 @@ func parsePath(name string) (ret gmPath) {
 			return
 		}
 		switch ext {
-		case ".mod", ".ziphash", ".info":
+		case ".mod", ".ziphash", ".info", ".zip":
 			ret.CacheDownloadFileExt = ext[1:]
 		default:
 			// Not a recognized cache/download file.

--- a/webdav.go
+++ b/webdav.go
@@ -93,6 +93,10 @@ func (d webdavFS) Stat(ctx context.Context, name string) (fi os.FileInfo, retErr
 		return regFileInfo{name: name, size: 123}, nil
 	}
 	if ext := dp.CacheDownloadFileExt; ext != "" {
+		if ext == "zip" {
+			// The "zip" file is unused by cmd/go, so just return an empty file.
+			return regFileInfo{name: name, size: 0}, nil
+		}
 		sp := d.fs.Stats.StartSpan("webdav.Stat-et-" + ext)
 		v, err := d.fs.getMetaFileByExt(ctx, dp.ModVersion, ext)
 		sp.End(err)


### PR DESCRIPTION
Updates tailscale/corp#35834

Signed-off-by: Brad Fitzpatrick <bradfitz@tailscale.com>
