### PR TITLE
path.{go,_test.go}: revert special casing staticcheck

### DIFF
--- a/path.go
+++ b/path.go
@@ -131,16 +131,6 @@ func parsePath(name string) (ret gmPath) {
 			ret.NotExist = true
 			return
 		}
-
-		// staticcheck walks the directory, looking for staticcheck.conf and
-		// does not stop at '@' - make sure we don't tell it that there is a
-		// foo/bar/staticcheck.conf directory that it will then attempt to parse
-		// as its config file.
-		// https://github.com/tailscale/gomodfs/issues/17
-		if base == "staticcheck.conf" {
-			ret.NotExist = true
-			return
-		}
 		return
 	}
 	escVer, path, _ := strings.Cut(verAndPath, "/")

--- a/path_test.go
+++ b/path_test.go
@@ -86,9 +86,6 @@ var pathTests = []struct {
 	{path: "foo/bar/baz", want: gmPath{}},
 	{path: "foo/bar/baz", want: gmPath{}},
 
-	// https://github.com/tailscale/gomodfs/issues/17
-	{path: "github.com/go4.org/staticcheck.conf", want: gmPath{NotExist: true}},
-	{path: "github.com/go4.org/mem/staticcheck.conf", want: gmPath{NotExist: true}},
 	{
 		path: "github.com/go4.org/mem@v2.17.2/staticcheck.conf",
 		want: gmPath{


### PR DESCRIPTION
As of https://github.com/dominikh/go-tools/commit/0c74f99fbc9b50f6a279058f3f3aee5842b1656d we can skip special casing staticcheck.conf.

I've tested that this works as expected.

Reverts #18 apart from one test case.

Updates #17