### PR TITLE
fuse: set the "ro" option

### DIFF
--- a/fuse.go
+++ b/fuse.go
@@ -38,6 +38,7 @@ func (f *FS) MountFUSE(mntPoint string, opt *MountOpts) (MountRunner, error) {
 			Debug:         opt.Debug,
 			FsName:        "gomodfs",
 			DisableXAttrs: true,
+			Options:       []string{"ro"},
 		},
 	}
 


### PR DESCRIPTION
This lets the kernel reply with EROFS early, rather than asking our
FUSE handlers to do it.

Plus: darwin wasn't returning EROFS, empirically. Rather, it was
returning EPERM for some reason (maybe it was evaluating the
permissions on the directories in the kernel instead?)

But now "mount" etc show read-only on macOS:

    gomodfs on /Users/bradfitz/gomodfs (macfuse, nodev, nosuid, read-only, synchronous, mounted by bradfitz)
