### PR TITLE
fix tsgo ".extracted" to contain hash, not just empty file

### DIFF
--- a/fuse.go
+++ b/fuse.go
@@ -623,7 +623,7 @@ func (f *statusFileNode) Getattr(_ context.Context, h fs.FileHandle, out *fuse.A
 // It pretends to the GOOS as given by the "goos" and "goarch" fields.
 //
 // It can contain two types of entries:
-//  1. ${git-hash}.extracted empty file
+//  1. ${git-hash}.extracted file containing the git hash and a newline
 //  2. ${git-hash}/ directory of contents
 //
 // Where git-hash is the hash of a github.com/tailscale/go
@@ -660,9 +660,8 @@ func (n *tsgoRoot) Lookup(ctx context.Context, name string, out *fuse.EntryOut) 
 	setLongTTL(out)
 
 	if wantExtractedFile {
-		// If it's a file, it must be an empty file.
 		in := n.NewInode(ctx, &memFile{
-			contents: []byte{},
+			contents: tsgoExtractedFileContents(hash),
 			mode:     0644,
 		}, fs.StableAttr{
 			Mode: fuse.S_IFREG | 0644,

--- a/nfs.go
+++ b/nfs.go
@@ -219,9 +219,10 @@ func (b billyFS) Lstat(filename string) (os.FileInfo, error) {
 		m := b.h.statusFile()
 		return m.fi, nil
 	case wkTSGoExtracted:
+		trip, _ := isTSGoModule(mp.ModVersion)
 		return regFileInfo{
-			name:       "TODO-tsgo-hash.extracted", // TODO(bradfitz): does it matter?
-			size:       0,                          // empty file
+			name:       path.Base(filename),
+			size:       int64(len(tsgoExtractedFileContents(trip.Hash))),
 			mode:       0444,
 			modTimeNow: true,
 		}, nil
@@ -667,7 +668,8 @@ func (n *NFSHandler) getFileContentsUncached(ctx context.Context, filename strin
 	case "":
 		// nothing
 	case wkTSGoExtracted:
-		return nil, attr, nil
+		trip, _ := isTSGoModule(mp.ModVersion)
+		return tsgoExtractedFileContents(trip.Hash), attr, nil
 	case statusFile:
 		m := n.statusFile()
 		setNFSTime(attr, m.fi.ModTime())

--- a/nfs_test.go
+++ b/nfs_test.go
@@ -276,7 +276,7 @@ func TestNFSHandles(t *testing.T) {
 	})
 
 	wantRegSize(t, h1, "go4.org@v0.0.0-20230225012048-214862532bf5/media/heif/heif.go", 7434)
-	wantRegSize(t, h1, "tsgo-linux-amd64/1cd3bf1a6eaf559aa8c00e749289559c884cef09.extracted", 0)
+	wantRegSize(t, h1, "tsgo-linux-amd64/1cd3bf1a6eaf559aa8c00e749289559c884cef09.extracted", 41)
 	wantRegSize(t, h1, "tsgo-linux-amd64/1cd3bf1a6eaf559aa8c00e749289559c884cef09/README", 3)
 	wantRegSize(t, h1, "tsgo-linux-amd64/1cd3bf1a6eaf559aa8c00e749289559c884cef09/bin/gofmt", 49)
 	wantRegSize(t, h1, "github.com/!azure/azure-sdk-for-go/sdk/azcore@v1.11.0/arm/runtime/policy_trace_namespace_test.go", 3215)

--- a/tsgo.go
+++ b/tsgo.go
@@ -24,6 +24,12 @@ var (
 
 const wkTSGoExtracted = "tsgo.extracted"
 
+// tsgoExtractedFileContents returns the contents of a
+// ${git-hash}.extracted file, which is the hash followed by a newline.
+func tsgoExtractedFileContents(hash string) []byte {
+	return fmt.Appendf(nil, "%s\n", hash)
+}
+
 func validTSGoOSARCH(goos, goarch string) bool {
 	// Keep this in sync with above.
 	switch goos {

--- a/webdav.go
+++ b/webdav.go
@@ -90,6 +90,10 @@ func (d webdavFS) Stat(ctx context.Context, name string) (fi os.FileInfo, retErr
 		return nil, os.ErrNotExist
 	}
 	if dp.WellKnown != "" {
+		if dp.WellKnown == wkTSGoExtracted {
+			trip, _ := isTSGoModule(dp.ModVersion)
+			return regFileInfo{name: name, size: int64(len(tsgoExtractedFileContents(trip.Hash)))}, nil
+		}
 		return regFileInfo{name: name, size: 123}, nil
 	}
 	if ext := dp.CacheDownloadFileExt; ext != "" {
@@ -172,7 +176,8 @@ func (d webdavFS) OpenFile(ctx context.Context, name string, flag int, perm os.F
 		case statusFile:
 			return newWDFileFromContents(base, d.fs.StatusJSON()), nil
 		case wkTSGoExtracted:
-			return newWDFileFromContents(base, nil), nil
+			trip, _ := isTSGoModule(dp.ModVersion)
+			return newWDFileFromContents(base, tsgoExtractedFileContents(trip.Hash)), nil
 		}
 		return nil, os.ErrNotExist
 	}

--- a/winfsp.go
+++ b/winfsp.go
@@ -168,7 +168,8 @@ func (pfs *fspFS) Stat(name string) (fi os.FileInfo, retErr error) {
 		if dp.WellKnown == statusFile {
 			return statusStat, nil
 		}
-		return regFileInfo{name: name, size: 123}, nil
+		trip, _ := isTSGoModule(dp.ModVersion)
+		return regFileInfo{name: name, size: int64(len(tsgoExtractedFileContents(trip.Hash)))}, nil
 	}
 	if ext := dp.CacheDownloadFileExt; ext != "" {
 		sp := d.fs.Stats.StartSpan("fsp.Stat-et-" + ext)
@@ -263,7 +264,8 @@ func (pfs *fspFS) OpenFile(name string, flag int, perm os.FileMode) (retFile gof
 		case statusFile:
 			return newFWPFileFromContents(base, pfs.fs.StatusJSON()), nil
 		case wkTSGoExtracted:
-			return newFWPFileFromContents(base, nil), nil
+			trip, _ := isTSGoModule(dp.ModVersion)
+			return newFWPFileFromContents(base, tsgoExtractedFileContents(trip.Hash)), nil
 		}
 		return nil, os.ErrNotExist
 	}


### PR DESCRIPTION
I had misremembered how these work. gocross is stricter.

Updates tailscale/corp#38147
